### PR TITLE
Use Dependabot for weekly npm and composer updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "08:00"
+      timezone: "Europe/Amsterdam"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "08:00"
+      timezone: "Europe/Amsterdam"


### PR DESCRIPTION
## Changes:

- Use Dependabot for weekly npm and composer updates

## Context:

Dependabot will check for updates on monday morning 8 o'clock Dutch time.

I think Dependabot does a run right away, and from then on it will stick to the schedule.
So you might still get update pull requests right away.

If you later add GitHub Actions runners, remember to get those updated with Dependabot as well. :wink: 

Closes #1.

